### PR TITLE
[archived] Add basic factory

### DIFF
--- a/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow.cc
+++ b/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow.cc
@@ -138,4 +138,7 @@ void __cls_init() {
 
   cls_register_cxx_method(h_class, "write", CLS_METHOD_RD | CLS_METHOD_WR, write,
                           &h_write);
+
+  cls_register_cxx_method(h_class, "read", CLS_METHOD_RD | CLS_METHOD_WR, read,
+                          &h_read);
 }

--- a/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow.cc
+++ b/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow.cc
@@ -115,7 +115,7 @@ static int read_and_scan(cls_method_context_t hctx, ceph::buffer::list* in,
 }
 
 static int read(cls_method_context_t hctx, ceph::buffer::list* in,
-                ceph::buffer::list *out) {
+                ceph::buffer::list* out) {
   int ret;
   ceph::buffer::list bl;
   ret = cls_cxx_read(hctx, 0, 0, &bl);
@@ -139,6 +139,5 @@ void __cls_init() {
   cls_register_cxx_method(h_class, "write", CLS_METHOD_RD | CLS_METHOD_WR, write,
                           &h_write);
 
-  cls_register_cxx_method(h_class, "read", CLS_METHOD_RD | CLS_METHOD_WR, read,
-                          &h_read);
+  cls_register_cxx_method(h_class, "read", CLS_METHOD_RD | CLS_METHOD_WR, read, &h_read);
 }

--- a/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow.cc
+++ b/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow.cc
@@ -29,6 +29,7 @@ CLS_NAME(arrow)
 cls_handle_t h_class;
 cls_method_handle_t h_read_and_scan;
 cls_method_handle_t h_write;
+cls_method_handle_t h_read;
 
 /// \brief Write data to an object.
 ///
@@ -110,6 +111,20 @@ static int read_and_scan(cls_method_context_t hctx, ceph::buffer::list* in,
   }
   *out = result_bl;
 
+  return 0;
+}
+
+static int read(cls_method_context_t hctx, ceph::buffer::list* in,
+                ceph::buffer::list *out) {
+  int ret;
+  ceph::buffer::list bl;
+  ret = cls_cxx_read(hctx, 0, 0, &bl);
+  if (ret < 0) {
+    CLS_ERR("ERROR: failed to read an object");
+    return ret;
+  }
+
+  *out = bl;
   return 0;
 }
 

--- a/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow_test.cc
+++ b/cpp/src/arrow/adapters/arrow-rados-cls/cls_arrow_test.cc
@@ -197,8 +197,10 @@ TEST(ClsSDK, TestEndToEnd) {
   for (int i = 0; i < 4; i++)
     objects.push_back(
         std::make_shared<arrow::dataset::RadosObject>("obj." + std::to_string(i)));
-  auto rados_ds =
-      std::make_shared<arrow::dataset::RadosDataset>(schema, objects, options);
+
+  arrow::dataset::FinishOptions finish_options;
+  auto rados_ds_factory = arrow::dataset::RadosDatasetFactory::Make(objects, options).ValueOrDie();
+  auto rados_ds = rados_ds_factory->Finish(finish_options).ValueOrDie();
 
   /// Prepare RecordBatches and Write the fragments.
   auto record_batches = create_test_record_batches();

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -41,7 +41,6 @@ std::shared_ptr<RadosOptions> RadosOptions::FromPoolName(std::string pool_name) 
   options->flags_ = 0;
   options->ceph_config_path_ = "/etc/ceph/ceph.conf";
   options->cls_name_ = "arrow";
-  options->cls_method_ = "read_and_scan";
   options->rados_interface_ = new RadosWrapper();
   options->io_ctx_interface_ = new IoCtxWrapper();
   return options;
@@ -194,7 +193,7 @@ Result<RecordBatchIterator> RadosScanTask::Execute() {
   /// bufferlist subsequently.
   int e = rados_options_->io_ctx_interface_->exec(
       object_->id(), rados_options_->cls_name_.c_str(),
-      rados_options_->cls_method_.c_str(), in, out);
+      "read_and_scan", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
   }

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -97,7 +97,7 @@ Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas
     InspectOptions options) {
   librados::bufferlist in, out;
   int e = rados_options_->io_ctx_interface_->exec(objects_[0]->id(),
-                                            rados_options_->cls_name_.c_str(), "read", in, out);
+      rados_options_->cls_name_.c_str(), "read", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
   }

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -24,6 +24,7 @@
 
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/filter.h"
+#include "arrow/dataset/discovery.h"
 #include "arrow/table.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/iterator.h"
@@ -86,7 +87,7 @@ struct VectorObjectGenerator : RadosDataset::RadosObjectGenerator {
   RadosObjectVector objects_;
 };
 
-RadosDatasetFactory::Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> options) {
+Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> options) {
   return std::make_shared<RadosDatasetFactory>(objects, options);
 }
 

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -96,8 +96,8 @@ Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(
 Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas(
     InspectOptions options) {
   librados::bufferlist in, out;
-  int e = options_->io_ctx_interface_->exec(objects_[0]->id(),
-                                            options_->cls_name_.c_str(), "read", in, out);
+  int e = rados_options_->io_ctx_interface_->exec(objects_[0]->id(),
+                                            rados_options_->cls_name_.c_str(), "read", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
   }
@@ -111,7 +111,7 @@ Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas
 Result<std::shared_ptr<Dataset>> RadosDatasetFactory::Finish(FinishOptions options) {
   InspectOptions inspect_options_;
   ARROW_ASSIGN_OR_RAISE(auto schemas_, InspectSchemas(inspect_options_));
-  return std::make_shared<RadosDataset>(schemas_[0], objects_, options_);
+  return std::make_shared<RadosDataset>(schemas_[0], objects_, rados_options_);
 }
 
 RadosDataset::RadosDataset(std::shared_ptr<Schema> schema, RadosObjectVector objects,

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -87,8 +87,8 @@ struct VectorObjectGenerator : RadosDataset::RadosObjectGenerator {
   RadosObjectVector objects_;
 };
 
-Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> options) {
-  return std::shared_ptr<DatasetFactory>(new RadosDatasetFactory(std::move(objects), std::move(options)));
+Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options) {
+  return std::shared_ptr<DatasetFactory>(new RadosDatasetFactory(std::move(objects), std::move(rados_options)));
 }
 
 Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas(InspectOptions options) {

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -88,12 +88,13 @@ struct VectorObjectGenerator : RadosDataset::RadosObjectGenerator {
 };
 
 Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> options) {
-  return std::make_shared<RadosDatasetFactory>(objects, options);
+  return std::shared_ptr<DatasetFactory>(new RadosDatasetFactory(std::move(objects), std::move(options)));
 }
 
-Result<std::shared_ptr<Schema>> RadosDatasetFactory::Inspect(InspectOptions options) {
-  int e = rados_options_->io_ctx_interface_->exec(
-      objects_[0]->id(), rados_options_->cls_name_.c_str(),
+Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas(InspectOptions options) {
+  librados::bufferlist in, out;
+  int e = options_->io_ctx_interface_->exec(
+      objects_[0]->id(), options_->cls_name_.c_str(),
       "read", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
@@ -102,13 +103,13 @@ Result<std::shared_ptr<Schema>> RadosDatasetFactory::Inspect(InspectOptions opti
   /// Deserialize the result Table from the `out` bufferlist.
   std::shared_ptr<Table> table;
   ARROW_RETURN_NOT_OK(deserialize_table_from_bufferlist(&table, out));
-  return table->schema();
+  return std::vector<std::shared_ptr<Schema>>{table->schema()};
 }
 
 Result<std::shared_ptr<Dataset>> RadosDatasetFactory::Finish(FinishOptions options) {
   InspectOptions inspect_options_;
-  ARROW_ASSIGN_OR_RAISE(auto schema_, Inspect(inspect_options_));
-  return std::make_shared<RadosDataset>(schema_, objects_, options_);
+  ARROW_ASSIGN_OR_RAISE(auto schemas_, InspectSchemas(inspect_options_));
+  return std::make_shared<RadosDataset>(schemas_[0], objects_, options_);
 }
 
 RadosDataset::RadosDataset(std::shared_ptr<Schema> schema, RadosObjectVector objects,

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -23,8 +23,8 @@
 #include <utility>
 
 #include "arrow/dataset/dataset_internal.h"
-#include "arrow/dataset/filter.h"
 #include "arrow/dataset/discovery.h"
+#include "arrow/dataset/filter.h"
 #include "arrow/table.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/iterator.h"
@@ -87,15 +87,17 @@ struct VectorObjectGenerator : RadosDataset::RadosObjectGenerator {
   RadosObjectVector objects_;
 };
 
-Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options) {
-  return std::shared_ptr<DatasetFactory>(new RadosDatasetFactory(std::move(objects), std::move(rados_options)));
+Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(
+    RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options) {
+  return std::shared_ptr<DatasetFactory>(
+      new RadosDatasetFactory(std::move(objects), std::move(rados_options)));
 }
 
-Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas(InspectOptions options) {
+Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas(
+    InspectOptions options) {
   librados::bufferlist in, out;
-  int e = options_->io_ctx_interface_->exec(
-      objects_[0]->id(), options_->cls_name_.c_str(),
-      "read", in, out);
+  int e = options_->io_ctx_interface_->exec(objects_[0]->id(),
+                                            options_->cls_name_.c_str(), "read", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
   }
@@ -194,8 +196,7 @@ Result<RecordBatchIterator> RadosScanTask::Execute() {
   /// down to the storage. The resultant Table will be available inside the `out`
   /// bufferlist subsequently.
   int e = rados_options_->io_ctx_interface_->exec(
-      object_->id(), rados_options_->cls_name_.c_str(),
-      "read_and_scan", in, out);
+      object_->id(), rados_options_->cls_name_.c_str(), "read_and_scan", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
   }

--- a/cpp/src/arrow/dataset/dataset_rados.cc
+++ b/cpp/src/arrow/dataset/dataset_rados.cc
@@ -96,8 +96,8 @@ Result<std::shared_ptr<DatasetFactory>> RadosDatasetFactory::Make(
 Result<std::vector<std::shared_ptr<Schema>>> RadosDatasetFactory::InspectSchemas(
     InspectOptions options) {
   librados::bufferlist in, out;
-  int e = rados_options_->io_ctx_interface_->exec(objects_[0]->id(),
-      rados_options_->cls_name_.c_str(), "read", in, out);
+  int e = rados_options_->io_ctx_interface_->exec(
+      objects_[0]->id(), rados_options_->cls_name_.c_str(), "read", in, out);
   if (e != 0) {
     return Status::ExecutionError("call to exec() returned non-zero exit code.");
   }

--- a/cpp/src/arrow/dataset/dataset_rados.h
+++ b/cpp/src/arrow/dataset/dataset_rados.h
@@ -111,6 +111,64 @@ class ARROW_DS_EXPORT RadosFragment : public Fragment {
   std::shared_ptr<RadosOptions> rados_options_;
 };
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
+ public:
+  static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, RadosOptions options);
+
+  Result<std::shared_ptr<Schema>> Inspect(
+      InspectOptions options) override;
+
+  Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
+
+ protected:
+  RadosDatasetFactory(RadosObjectVector objects, std::shared_ptr<RadosOptions> options)
+    : objects_(objects), options_(std::move(options)) {}
+  RadosObjectVector objects_;
+  std::shared_ptr<RadosOptions> options_;
+};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /// \brief A Dataset to wrap a vector of RadosObjects and generate
 /// RadosFragments out of them.
 class ARROW_DS_EXPORT RadosDataset : public Dataset {

--- a/cpp/src/arrow/dataset/dataset_rados.h
+++ b/cpp/src/arrow/dataset/dataset_rados.h
@@ -113,10 +113,10 @@ class ARROW_DS_EXPORT RadosFragment : public Fragment {
 
 class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
  public:
-  static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, RadosOptions options);
+  static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> options);
 
-  Result<std::shared_ptr<Schema>> Inspect(
-      InspectOptions options) override;
+  Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas(
+      InspectOptions options);
 
   Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
 

--- a/cpp/src/arrow/dataset/dataset_rados.h
+++ b/cpp/src/arrow/dataset/dataset_rados.h
@@ -28,6 +28,7 @@
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/rados.h"
 #include "arrow/dataset/scanner.h"
+#include "arrow/dataset/discovery.h"
 
 namespace arrow {
 namespace dataset {
@@ -110,27 +111,6 @@ class ARROW_DS_EXPORT RadosFragment : public Fragment {
   std::shared_ptr<RadosOptions> rados_options_;
 };
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
  public:
   static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, RadosOptions options);
@@ -146,27 +126,6 @@ class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
   RadosObjectVector objects_;
   std::shared_ptr<RadosOptions> options_;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 /// \brief A Dataset to wrap a vector of RadosObjects and generate
 /// RadosFragments out of them.

--- a/cpp/src/arrow/dataset/dataset_rados.h
+++ b/cpp/src/arrow/dataset/dataset_rados.h
@@ -26,9 +26,9 @@
 #include <vector>
 
 #include "arrow/dataset/dataset.h"
+#include "arrow/dataset/discovery.h"
 #include "arrow/dataset/rados.h"
 #include "arrow/dataset/scanner.h"
-#include "arrow/dataset/discovery.h"
 
 namespace arrow {
 namespace dataset {
@@ -113,7 +113,7 @@ class ARROW_DS_EXPORT RadosFragment : public Fragment {
 
 /// \brief A factory to create a RadosDataset from a vector of RadosObjects.
 ///
-/// The factory takes a vector of RadosObjects and infers the schema of the Table 
+/// The factory takes a vector of RadosObjects and infers the schema of the Table
 /// stored in the objects by scanning the first object in the list.
 class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
  public:
@@ -121,16 +121,17 @@ class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
   ///
   /// \param[in] objects a vector of RadosObjects.
   /// \param[in] rados_options the connection information to the RADOS cluster.
-  static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options);
+  static Result<std::shared_ptr<DatasetFactory>> Make(
+      RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options);
 
-  Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas(
-      InspectOptions options);
+  Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas(InspectOptions options);
 
   Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
 
  protected:
-  RadosDatasetFactory(RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options)
-    : objects_(objects), rados_options_(std::move(rados_options)) {}
+  RadosDatasetFactory(RadosObjectVector objects,
+                      std::shared_ptr<RadosOptions> rados_options)
+      : objects_(objects), rados_options_(std::move(rados_options)) {}
   RadosObjectVector objects_;
   std::shared_ptr<RadosOptions> rados_options_;
 };

--- a/cpp/src/arrow/dataset/dataset_rados.h
+++ b/cpp/src/arrow/dataset/dataset_rados.h
@@ -111,9 +111,17 @@ class ARROW_DS_EXPORT RadosFragment : public Fragment {
   std::shared_ptr<RadosOptions> rados_options_;
 };
 
+/// \brief A factory to create a RadosDataset from a vector of RadosObjects.
+///
+/// The factory takes a vector of RadosObjects and infers the schema of the Table 
+/// stored in the objects by scanning the first object in the list.
 class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
  public:
-  static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> options);
+  /// \brief Build a RadosDataset from a vector of RadosObjects.
+  ///
+  /// \param[in] objects a vector of RadosObjects.
+  /// \param[in] rados_options the connection information to the RADOS cluster.
+  static Result<std::shared_ptr<DatasetFactory>> Make(RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options);
 
   Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas(
       InspectOptions options);
@@ -121,10 +129,10 @@ class ARROW_DS_EXPORT RadosDatasetFactory : public DatasetFactory {
   Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
 
  protected:
-  RadosDatasetFactory(RadosObjectVector objects, std::shared_ptr<RadosOptions> options)
-    : objects_(objects), options_(std::move(options)) {}
+  RadosDatasetFactory(RadosObjectVector objects, std::shared_ptr<RadosOptions> rados_options)
+    : objects_(objects), rados_options_(std::move(rados_options)) {}
   RadosObjectVector objects_;
-  std::shared_ptr<RadosOptions> options_;
+  std::shared_ptr<RadosOptions> rados_options_;
 };
 
 /// \brief A Dataset to wrap a vector of RadosObjects and generate

--- a/cpp/src/arrow/dataset/dataset_rados.h
+++ b/cpp/src/arrow/dataset/dataset_rados.h
@@ -62,7 +62,6 @@ struct ARROW_DS_EXPORT RadosOptions {
   std::string ceph_config_path_;
   uint64_t flags_;
   std::string cls_name_;
-  std::string cls_method_;
 
   RadosInterface* rados_interface_;
   IoCtxInterface* io_ctx_interface_;

--- a/cpp/src/arrow/dataset/dataset_rados_test.cc
+++ b/cpp/src/arrow/dataset/dataset_rados_test.cc
@@ -188,6 +188,10 @@ TEST_F(TestRadosFragment, Scan) {
 
 class TestRadosDataset : public DatasetFixtureMixin {};
 
+TEST_F(TestRadosDataset, Factory) {
+  
+}
+
 TEST_F(TestRadosDataset, GetFragments) {
   constexpr int64_t kNumberBatches = 24;
 

--- a/cpp/src/arrow/dataset/dataset_rados_test.cc
+++ b/cpp/src/arrow/dataset/dataset_rados_test.cc
@@ -188,8 +188,6 @@ TEST_F(TestRadosFragment, Scan) {
 
 class TestRadosDataset : public DatasetFixtureMixin {};
 
-TEST_F(TestRadosDataset, Factory) {}
-
 TEST_F(TestRadosDataset, GetFragments) {
   constexpr int64_t kNumberBatches = 24;
 

--- a/cpp/src/arrow/dataset/dataset_rados_test.cc
+++ b/cpp/src/arrow/dataset/dataset_rados_test.cc
@@ -188,9 +188,7 @@ TEST_F(TestRadosFragment, Scan) {
 
 class TestRadosDataset : public DatasetFixtureMixin {};
 
-TEST_F(TestRadosDataset, Factory) {
-  
-}
+TEST_F(TestRadosDataset, Factory) {}
 
 TEST_F(TestRadosDataset, GetFragments) {
   constexpr int64_t kNumberBatches = 24;


### PR DESCRIPTION
To use dataset API from coffea, to query uproot data, we cannot pass a schema to the RadosDataset API. That's why adding a simple Factory to infer the schema from the first object as in the case of parquet dataset factory.