### PR TITLE
Fix uninitialized value

### DIFF
--- a/cpp/src/arrow/dataset/file_rados_parquet.cc
+++ b/cpp/src/arrow/dataset/file_rados_parquet.cc
@@ -46,7 +46,7 @@ class RadosParquetScanTask : public ScanTask {
     ceph::bufferlist* out = new ceph::bufferlist();
 
     Status s;
-    struct stat st;
+    struct stat st{};
     s = doa_->Stat(source_.path(), st);
     if (!s.ok()) {
       return Status::Invalid(s.message());


### PR DESCRIPTION
Simple fix to remove uninitialized value from `file_rados_parquet.cc`.